### PR TITLE
Fix missing selenium requirement and add pip check.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,9 @@ test:
     - urlchecker.version
   commands:
     - urlchecker --help
+    - pip check
+  requires:
+    - pip
 
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: e303c4d240f3e00e21583bf9636e6792b4d7abd889de5b3114e78662cd2b7f45
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - urlchecker=urlchecker.client:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - python >=3
     - requests
     - fake-useragent
+    - selenium
 
 test:
   imports:


### PR DESCRIPTION
Last week, `selenium` was added to the requirements of urlchecker (https://github.com/urlstechie/urlchecker-python/commit/c7d209d9054a287d1a3fdb49719a66ddf622f936#diff-b4da9b16e68726ec7e4c331494f2229d7d1bd066099db6fcbc8375f1d29ed9a0) but it was not yet added in the conda-forge build, which makes pip check fail with: `urlchecker 0.0.35 requires selenium, which is not installed.` (see [here](https://git.gfz-potsdam.de/EnMAP/GFZ_Tools_EnMAP_BOX/EnPT/-/jobs/222629)).

This PR adds selenium and also adds pip check to make sure future conda-forge builds fails if requirements are missing.


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
